### PR TITLE
Use rockcraft 1.3.0 candidate to build entrypoint-service coredns

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -14,6 +14,8 @@ jobs:
       trivy-image-config: "trivy.yaml"
       multiarch-awareness: true
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
+      # pinning to use rockcraft 1.3.0 feature `entrypoint-service`
+      rockcraft-revision: "1783"
       platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
   scan-images:
     uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@main

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -12,12 +12,12 @@ jobs:
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
-      multiarch-awareness: false
+      multiarch-awareness: true
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
       # pinning to use rockcraft 1.3.0 feature `entrypoint-service`
-      rockcraft-revision: "1783"
-      # arch-skipping-maximize-build-space: '["arm64"]'
-      # platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
+      rockcraft-revisions: '{"amd64": "1783", "arm64": "1784"}'
+      arch-skipping-maximize-build-space: '["arm64"]'
+      platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
   scan-images:
     uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@main
     needs: [build-and-push-arch-specifics]

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -16,6 +16,7 @@ jobs:
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
       # pinning to use rockcraft 1.3.0 feature `entrypoint-service`
       rockcraft-revision: "1783"
+      arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
   scan-images:
     uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@main

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -12,12 +12,12 @@ jobs:
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
-      multiarch-awareness: true
+      multiarch-awareness: false
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
       # pinning to use rockcraft 1.3.0 feature `entrypoint-service`
       rockcraft-revision: "1783"
-      arch-skipping-maximize-build-space: '["arm64"]'
-      platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
+      # arch-skipping-maximize-build-space: '["arm64"]'
+      # platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
   scan-images:
     uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@main
     needs: [build-and-push-arch-specifics]

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -10,6 +10,7 @@ platforms:
   amd64:
   arm64:
 
+entrypoint-service: coredns
 services:
   coredns:
     override: replace


### PR DESCRIPTION
Use `entrypoint-service` in rockcraft 1.3.0 so we can use a stock chart for coredns with this image

depends on workflow changes first being merged:
*  https://github.com/canonical/k8s-workflows/pull/8 