### PR TITLE
Optimize rockcraft build

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@story/KU-1195/fix-when-image-not-present
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@main
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -15,7 +15,7 @@ jobs:
       multiarch-awareness: true
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
       # pinning to use rockcraft 1.3.0 feature `entrypoint-service`
-      rockcraft-revisions: '{"amd64": "2218", "arm64": "1784"}'
+      rockcraft-revisions: '{"amd64": "2218", "arm64": "2222"}'
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
   scan-images:
@@ -34,4 +34,3 @@ jobs:
     with:
       rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas }}
       dry-run: ${{ github.event_name != 'push' }}
-#test3

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -18,6 +18,12 @@ jobs:
       rockcraft-revisions: '{"amd64": "2218", "arm64": "2222"}'
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
+  run-tests:
+    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main
+    needs: [build-and-push-arch-specifics]
+    secrets: inherit
+    with:
+      rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.rock-metas }}
   scan-images:
     uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@main
     needs: [build-and-push-arch-specifics]

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -15,7 +15,7 @@ jobs:
       multiarch-awareness: true
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
       # pinning to use rockcraft 1.3.0 feature `entrypoint-service`
-      rockcraft-revisions: '{"amd64": "1783", "arm64": "1784"}'
+      rockcraft-revisions: '{"amd64": "2218", "arm64": "1784"}'
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
   scan-images:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -30,6 +30,7 @@ jobs:
     name: Combine Rocks and Push Multiarch Manifest
     uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@main
     needs: [build-and-push-arch-specifics]
+    if: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas != '[]' }}
     with:
-      rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.rock-metas }}
+      rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas }}
       dry-run: ${{ github.event_name != 'push' }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@story/KU-1195/fix-when-image-not-present
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -34,3 +34,4 @@ jobs:
     with:
       rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas }}
       dry-run: ${{ github.event_name != 'push' }}
+#test2

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -34,4 +34,4 @@ jobs:
     with:
       rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas }}
       dry-run: ${{ github.event_name != 'push' }}
-#test2
+#test3

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -28,12 +28,10 @@ parts:
     source-depth: 1
     build-packages:
       - build-essential
-      - ca-certificates_data
-
     build-snaps:
       - go/1.21/stable
-    #    stage-packages:
-    #      - ca-certificates_data
+    stage-packages:
+      - ca-certificates_data
     override-build: |
       make
       cp $CRAFT_PART_BUILD/coredns $CRAFT_PRIME

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -28,10 +28,12 @@ parts:
     source-depth: 1
     build-packages:
       - build-essential
+      - ca-certificates_data
+
     build-snaps:
       - go/1.21/stable
-    stage-packages:
-      - ca-certificates_data
+    #    stage-packages:
+    #      - ca-certificates_data
     override-build: |
       make
       cp $CRAFT_PART_BUILD/coredns $CRAFT_PRIME


### PR DESCRIPTION
Currently, for each change in the rockcraft repo, we publish the current state of rockcraft files and run tests on them even if files haven’t changed. We need to build only changed files but run tests on all rock images.

The PR updates pushed images after the build to only those modified rocks and also, bump the rockcraft version which fixes the CI build.

KU-1195





