### PR TITLE
bump go version used for builds

### DIFF
--- a/1.11.4/rockcraft.yaml
+++ b/1.11.4/rockcraft.yaml
@@ -29,7 +29,7 @@ parts:
     build-packages:
       - build-essential
     build-snaps:
-      - go/1.21/stable
+      - go/1.23/stable
     stage-packages:
       - ca-certificates_data
     override-build: |

--- a/1.12.0/rockcraft.yaml
+++ b/1.12.0/rockcraft.yaml
@@ -29,7 +29,7 @@ parts:
     build-packages:
       - build-essential
     build-snaps:
-      - go/1.21/stable
+      - go/1.22/stable
     stage-packages:
       - ca-certificates_data
     override-build: |

--- a/1.12.0/rockcraft.yaml
+++ b/1.12.0/rockcraft.yaml
@@ -29,7 +29,7 @@ parts:
     build-packages:
       - build-essential
     build-snaps:
-      - go/1.22/stable
+      - go/1.23/stable
     stage-packages:
       - ca-certificates_data
     override-build: |


### PR DESCRIPTION
Need to rebuild the rock with the latest ubuntu base. While I'm here, update the go version used for the build (why not?)