### PR TITLE
feat: Make 1.12.0 FIPS compliant

### DIFF
--- a/1.12.0/rockcraft.yaml
+++ b/1.12.0/rockcraft.yaml
@@ -29,9 +29,14 @@ parts:
     build-packages:
       - build-essential
     build-snaps:
-      - go/1.23/stable
+      - go/1.23-fips/stable
+    stage-snaps:
+      - core22/fips-updates/stable
+    stage:
+      - -bin
     stage-packages:
       - ca-certificates_data
     override-build: |
-      make
-      cp $CRAFT_PART_BUILD/coredns $CRAFT_PRIME
+      CGO_ENABLED=1 make SYSTEM="GOTOOLCHAIN=local GOEXPERIMENT=opensslcrypto"
+      cp $CRAFT_PART_BUILD/coredns $CRAFT_PART_INSTALL
+


### PR DESCRIPTION
### Overview

This PR makes 1.12.0 FIPS compliant. This is inspired by https://github.com/canonical/coredns-rock/pull/38, but since we're actually using 1.12.0 in the k8s-snap, we need to make this version FIPS compliant as well.

Without this, coredns image fails to start with a `exec /bin/pebble: no such file or directory` error.

- Go channel is updated to use the one with the FIPS changes
- Uses core22 from the FIPS channel
- Provides certain environment variables for Go in order to build a FIPS-compliant binary

The other changes are also necessary since we're using a specific rockcraft revision (changed in the original PR)