### PR TITLE
ci: Include FIPS openssl in rockcraft parts

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -17,8 +17,7 @@ jobs:
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
       enabled-ubuntu-pro-features: "fips-updates"
-      multipass-image: "22.04"
-      rockcraft-revisions: '{"amd64": "3494"}'
+      rockcraft-revisions: '{"amd64": "3494", "arm64": "3547"}'
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:

--- a/1.12.1/rockcraft.yaml
+++ b/1.12.1/rockcraft.yaml
@@ -20,6 +20,11 @@ services:
     on-failure: shutdown
 
 parts:
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
   coredns:
     plugin: nil
     source: https://github.com/coredns/coredns
@@ -30,10 +35,6 @@ parts:
       - build-essential
     build-snaps:
       - go/1.23-fips/stable
-    stage-snaps:
-      - core22/fips-updates/stable
-    stage:
-      - -bin
     stage-packages:
       - ca-certificates_data
     override-build: |

--- a/1.12.2/rockcraft.yaml
+++ b/1.12.2/rockcraft.yaml
@@ -20,6 +20,11 @@ services:
     on-failure: shutdown
 
 parts:
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
   coredns:
     plugin: nil
     source: https://github.com/coredns/coredns
@@ -30,10 +35,6 @@ parts:
       - build-essential
     build-snaps:
       - go/1.23-fips/stable
-    stage-snaps:
-      - core22/fips-updates/stable
-    stage:
-      - -bin
     stage-packages:
       - ca-certificates_data
     override-build: |

--- a/1.12.3/rockcraft.yaml
+++ b/1.12.3/rockcraft.yaml
@@ -20,6 +20,11 @@ services:
     on-failure: shutdown
 
 parts:
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
   coredns:
     plugin: nil
     source: https://github.com/coredns/coredns
@@ -30,10 +35,6 @@ parts:
       - build-essential
     build-snaps:
       - go/1.23-fips/stable
-    stage-snaps:
-      - core22/fips-updates/stable
-    stage:
-      - -bin
     stage-packages:
       - ca-certificates_data
     override-build: |

--- a/build/template/rockcraft.yaml.in
+++ b/build/template/rockcraft.yaml.in
@@ -20,6 +20,11 @@ services:
     on-failure: shutdown
 
 parts:
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
   coredns:
     plugin: nil
     source: https://github.com/coredns/coredns
@@ -30,10 +35,6 @@ parts:
       - build-essential
     build-snaps:
       - go/1.23-fips/stable
-    stage-snaps:
-      - core22/fips-updates/stable
-    stage:
-      - -bin
     stage-packages:
       - ca-certificates_data
     override-build: |

--- a/docs/fips.md
+++ b/docs/fips.md
@@ -14,36 +14,6 @@ For the extended module, enduring the non-approved algorithms are not executed w
 ## Manual build and test
 
 To manually build the fips-compliant rock image you need an Ubuntu Pro token. Once obtained, you can follow these intructions:
-
-- Install multipass on a machine with enabled virtualization capabilities:
 ```
-sudo snap install multipass
-```
-- Launch a builder instance with an attached Ubuntu Pro account:
-```
-cat <<EOF | multipass launch --name rock-builder --cloud-init - --cpus 4 --disk 20GB --memory 8GB 22.04
-package_update: true
-package_upgrade: true
-packages:
-- ubuntu-advantage-tools
-runcmd:
-- pro attach <UBUNTU_PRO_TOKEN> --no-auto-enable
-- reboot
-EOF
-```
-- Install rockcraft from the `edge/pro-sources` channel
-```
-multipass exec rock-builder -- sudo snap install rockcraft --channel=edge/pro-sources --classic
-```
-- Initialize `lxd` on the machine 
-```
-multipass exec rock-builder -- lxd init --auto
-```
-- Switch to the directory where you `rockcraft.yaml` file is located and mount the directory on Multipass instance
-```
-multipass mount . rock-builder:/home/ubuntu/rock
-```
-- Pack the rock image with the `fips-updates` service enabled on both the build environment and the rock
-```
-multipass exec rock-builder -d /home/ubuntu/rock -- sudo rockcraft pack --pro=fips-updates
+sudo rockcraft pack --pro=fips-updates
 ```


### PR DESCRIPTION
### Overview

This PR builds on top of https://github.com/canonical/k8s-workflows/pull/50 and discards multipass as the build environment. Also enables building FIPS-enabled rocks on ARM and only includes OpenSSL from FIPS sources rather than the full core22.