### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -6,4 +6,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v2
+        uses: canonical/has-signed-canonical-cla@19bae73390fdbfdc1ef9a9bb9408d87a1de755f6 # v2

--- a/.github/workflows/update_version.yaml
+++ b/.github/workflows/update_version.yaml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout rock repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           path: coredns-rock
           ref: ${{ github.head_ref || 'main' }}
           ssh-key: ${{ secrets.BOT_SSH_KEY }}
 
       - name: Checkout coredns repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           repository: coredns/coredns
           path: coredns
@@ -44,7 +44,7 @@ jobs:
       - name: Commit and push new rockcraft.yaml
         id: commit-rockcraft
         if: ${{ steps.emit-rockcraft.outputs.tags != '[]' }}
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           author: Canonical Github Bot <actions@canonical.com>
           commit-message: Update CoreDNS versions with ${{ join(fromJSON(steps.emit-rockcraft.outputs.tags), ', ') }}


### PR DESCRIPTION
## Summary

Pin all GitHub Actions to full commit SHAs for supply-chain security hardening, replacing mutable tag references.

## Why

Mutable tags (e.g. `@v4`) can be moved by upstream maintainers or by an attacker who compromises an action repo. Pinning to a SHA ensures workflows always run exactly the reviewed code.

This follows GitHub's own security hardening guidance and improves our OpenSSF Scorecard rating.

## Changes

- Pinned all third-party and GitHub-maintained actions in workflow files to full 40-character commit SHAs
- Preserved original tag/branch versions in inline comments for readability
- Left already-pinned actions unchanged

## Testing

- Verified all `uses:` references in `.github/workflows/` now use immutable SHAs