### PR TITLE
ci: pin rockcraft to latest/edge channel for all versions

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@fix-lxd-guest-pro-attach
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
@@ -17,7 +17,7 @@ jobs:
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
       enabled-ubuntu-pro-features: "fips-updates"
-      rockcraft-revisions: '{"amd64": "3494", "arm64": "3547"}'
+      force-build: true
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@fix-lxd-guest-pro-attach
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@1f72669125e711d252c472f45ad98f22ff592d28
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
@@ -24,7 +24,6 @@ jobs:
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
       enabled-ubuntu-pro-features: "fips-updates"
-      force-build: true
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -5,9 +5,16 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
+    permissions:
+      contents: read
+      packages: write
     uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@fix-lxd-guest-pro-attach
     with:
       owner: ${{ github.repository_owner }}
@@ -27,6 +34,9 @@ jobs:
     with:
       rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.rock-metas }}
   scan-images:
+    permissions:
+      security-events: write
+      packages: read
     uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@main
     needs: [build-and-push-arch-specifics]
     secrets: inherit

--- a/1.11.1/.rockcraft-version.yaml
+++ b/1.11.1/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/1.11.3/.rockcraft-version.yaml
+++ b/1.11.3/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/1.11.4/.rockcraft-version.yaml
+++ b/1.11.4/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/1.12.0/.rockcraft-version.yaml
+++ b/1.12.0/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/1.12.1/.rockcraft-version.yaml
+++ b/1.12.1/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/1.12.2/.rockcraft-version.yaml
+++ b/1.12.2/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/1.12.3/.rockcraft-version.yaml
+++ b/1.12.3/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/1.12.4/.rockcraft-version.yaml
+++ b/1.12.4/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/1.13.0/.rockcraft-version.yaml
+++ b/1.13.0/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/1.13.1/.rockcraft-version.yaml
+++ b/1.13.1/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/1.13.2/.rockcraft-version.yaml
+++ b/1.13.2/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/1.14.0/.rockcraft-version.yaml
+++ b/1.14.0/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge

--- a/tests/requirements-dev.txt
+++ b/tests/requirements-dev.txt
@@ -3,4 +3,4 @@ codespell==2.2.4
 flake8==6.0.0
 isort==5.12.0
 licenseheaders==0.8.8
-k8s-test-harness @   git+https://github.com/canonical/k8s-test-harness@de46217
+k8s-test-harness @   git+https://github.com/canonical/k8s-test-harness@361be19

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,5 +1,5 @@
-coverage[toml]==7.2.5
+coverage[toml]
 pytest==7.3.1
 PyYAML==6.0.1
 tenacity==8.2.3
-k8s-test-harness @   git+https://github.com/canonical/k8s-test-harness@de46217
+k8s-test-harness @   git+https://github.com/canonical/k8s-test-harness@361be19

--- a/tests/sanity/test_rock.py
+++ b/tests/sanity/test_rock.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 import yaml
 from k8s_test_harness.util import docker_util, env_util
+from test_util import config
 
 TEST_PATH = Path(__file__)
 REPO_PATH = TEST_PATH.parent.parent.parent
@@ -28,3 +29,15 @@ def test_sanity(image_version):
 
     process = docker_util.run_in_docker(image, [entrypoint, "--version"])
     assert f"CoreDNS-{image_version}" in process.stdout
+
+
+@pytest.mark.parametrize("image_version", _image_versions())
+def test_pebble(image_version):
+    rock = env_util.get_build_meta_info_for_rock_version(
+        "coredns", image_version, "amd64"
+    )
+    docker_util.run_entrypoint_and_assert(
+        rock.image,
+        "/bin/pebble version",
+        expect_stdout_contains=config.PEBBLE_VERSION,
+    )

--- a/tests/sanity/test_util/config.py
+++ b/tests/sanity/test_util/config.py
@@ -1,0 +1,7 @@
+#
+# Copyright 2024 Canonical, Ltd.
+#
+
+import os
+
+PEBBLE_VERSION = os.getenv("COREDNS_PEBBLE_VERSION") or "fips"


### PR DESCRIPTION
## Summary
- Replace the repo-wide rockcraft revision pin (`3494`/`3547`) with a per-version `X.Y.Z/.rockcraft-version.yaml` selecting the `latest/edge` channel for all 12 versions.
- Switch the shared build workflow input `rockcraft-revisions` for `force-build: true`, and bump the build workflow ref to `@fix-lxd-guest-pro-attach`.
- **Fix the pre-existing `startup_failure`**: grant the caller jobs the token scopes the reusable workflows now require (`packages: write` for the build job, `security-events: write` + `packages: read` for `scan-images`), plus a `concurrency` group — mirroring `cilium-rocks`.
- Add a `test_pebble` sanity test (with `tests/sanity/test_util/config.py`) asserting the FIPS pebble build via `COREDNS_PEBBLE_VERSION` (default `fips`).

## Why
The shared build workflow's rockcraft resolution only walks the rock directory and its immediate parent, so a repo-root pin is never consulted for the nested version rocks. Placing a `.rockcraft-version.yaml` in each version directory makes the channel selection effective. Moving to `latest/edge` (plus `force-build`) is expected to pick up newer rockcraft handling of the FIPS apt-overlay.

Separately, the `Push Multiarch Images` build had been failing with `startup_failure` on **every PR since ~2026-05-19** (last green: `768a0dae`). A k8s-workflows `@main` change began requiring elevated `GITHUB_TOKEN` scopes that the coredns caller never granted, so the run could not start (0 jobs). `cilium-rocks` already carries the per-job `permissions` blocks and builds fine; this PR brings the coredns caller in line, and the build now starts and runs the full per-version matrix.

This mirrors the equivalent change in [`cilium-rocks` #59](https://github.com/canonical/cilium-rocks/pull/59).

## Notes
- No `pro-features` key is set in the new `.rockcraft-version.yaml` files, so they inherit `fips-updates` from the workflow.
- Only the `build_rocks.yaml` ref is bumped; `run_tests`, `scan_images`, and `assemble_multiarch_image` stay on `@main` (matching cilium-rocks #59).
- The new pebble test depends on the `latest/edge` rockcraft + `force-build` producing a FIPS pebble; `docs/fips.md` currently states pebble is not yet FIPS-built, so this test may fail until the toolchain catches up.
